### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.26.2-slim
+      - image: rust:1.39.0-slim
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/sfackler/typed-headers"
 readme = "README.md"
 
 [dependencies]
-base64 = "0.10"
-bytes = "0.4"
+base64 = "0.11"
+bytes = "0.5.2"
 chrono = "0.4"
-http = "0.1.15"
+http = "0.2"
 mime = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT/Apache-2.0"
 description = "Typed HTTP header serialization and deserialization."
 repository = "https://github.com/sfackler/typed-headers"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 base64 = "0.11"

--- a/src/impls/accept.rs
+++ b/src/impls/accept.rs
@@ -1,7 +1,7 @@
 use http::header::ACCEPT;
 use mime::Mime;
 
-use QualityItem;
+use super::QualityItem;
 
 header! {
     /// `Accept` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.2)
@@ -33,7 +33,7 @@ header! {
 
 #[cfg(test)]
 mod test {
-    use {util, Quality, QualityItem};
+    use crate::{util, Quality, QualityItem};
 
     use super::*;
 

--- a/src/impls/accept_encoding.rs
+++ b/src/impls/accept_encoding.rs
@@ -1,6 +1,6 @@
 use http::header::ACCEPT_ENCODING;
 
-use {ContentCoding, QualityItem};
+use super::{ContentCoding, QualityItem};
 
 header! {
     /// `Accept-Encoding` header, defined in

--- a/src/impls/authorization.rs
+++ b/src/impls/authorization.rs
@@ -1,6 +1,6 @@
 use http::header::AUTHORIZATION;
 
-use Credentials;
+use super::Credentials;
 
 header! {
     /// `Authorization` header, defined in [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.2)
@@ -26,7 +26,7 @@ header! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use {util, Token68};
+    use crate::{util, Token68};
 
     #[test]
     fn rfc1() {

--- a/src/impls/content_encoding.rs
+++ b/src/impls/content_encoding.rs
@@ -1,6 +1,6 @@
 use http::header::CONTENT_ENCODING;
 
-use ContentCoding;
+use super::ContentCoding;
 
 header! {
     /// `Content-Encoding` header, defined in

--- a/src/impls/content_length.rs
+++ b/src/impls/content_length.rs
@@ -1,7 +1,7 @@
 use http::header::{self, HeaderName, HeaderValue, CONTENT_LENGTH};
 use std::ops::{Deref, DerefMut};
 
-use {util, Error, Header, ToValues};
+use crate::{util, Error, Header, ToValues};
 
 /// `Content-Length` header, defined in
 /// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2)

--- a/src/impls/credentials.rs
+++ b/src/impls/credentials.rs
@@ -118,7 +118,7 @@ impl FromStr for Credentials {
             None => return Ok(Credentials::from_auth_scheme(auth_scheme)),
         };
 
-        let info = info.trim_left_matches(' ');
+        let info = info.trim_start_matches(' ');
 
         match info.parse::<Token68>() {
             Ok(token) => Ok(Credentials::from_token68(auth_scheme, token)),

--- a/src/impls/credentials.rs
+++ b/src/impls/credentials.rs
@@ -2,7 +2,8 @@ use base64;
 use std::fmt;
 use std::str::FromStr;
 
-use {AuthScheme, Error, Token68};
+use crate::Error;
+use super::{AuthScheme, Token68};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Info {

--- a/src/impls/host.rs
+++ b/src/impls/host.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use http::header::{self, HeaderName, HeaderValue, HOST};
 use http::uri::Authority;
 
-use {Error, Header, ToValues};
+use crate::{Error, Header, ToValues};
 
 /// The `Host` header, defined in [RFC7230].
 ///

--- a/src/impls/host.rs
+++ b/src/impls/host.rs
@@ -27,13 +27,13 @@ pub struct Host {
 impl Host {
     /// Creates a Host header from a hostname and optional port.
     #[inline]
-    pub fn new(host: &str, port: Option<u16>) -> Result<Host, Error> {
+    pub fn new(host: &'static str, port: Option<u16>) -> Result<Host, Error> {
         // go through authority to validate the hostname
         let authority = match port {
             Some(port) => Bytes::from(format!("{}:{}", host, port)),
             None => Bytes::from(host),
         };
-        let authority = Authority::from_shared(authority).map_err(|_| Error::invalid_value())?;
+        let authority = Authority::from_maybe_shared(authority).map_err(|_| Error::invalid_value())?;
 
         Ok(Host::from_authority(&authority))
     }
@@ -77,7 +77,7 @@ impl Header for Host {
             None => return Ok(None),
         };
 
-        let authority = Authority::from_shared(Bytes::from(value.as_bytes()))
+        let authority = Authority::from_maybe_shared(Bytes::copy_from_slice(value.as_bytes()))
             .map_err(|_| Error::invalid_value())?;
         // host header can't contain userinfo
         if authority.as_str().contains('@') {

--- a/src/impls/http_date.rs
+++ b/src/impls/http_date.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::time::SystemTime;
 
-use Error;
+use crate::Error;
 
 const IMF_FIXDATE_PATTERN: &'static str = "%a, %d %b %Y %T GMT";
 const RFC850_DATE_PATTERN: &'static str = "%A, %d-%b-%y %T GMT";

--- a/src/impls/mod.rs
+++ b/src/impls/mod.rs
@@ -1,19 +1,19 @@
-pub use impls::accept::Accept;
-pub use impls::accept_encoding::AcceptEncoding;
-pub use impls::allow::Allow;
-pub use impls::auth_scheme::AuthScheme;
-pub use impls::authorization::Authorization;
-pub use impls::content_coding::ContentCoding;
-pub use impls::content_encoding::ContentEncoding;
-pub use impls::content_length::ContentLength;
-pub use impls::content_type::ContentType;
-pub use impls::credentials::Credentials;
-pub use impls::host::Host;
-pub use impls::http_date::HttpDate;
-pub use impls::proxy_authorization::ProxyAuthorization;
-pub use impls::quality::{Quality, QualityItem};
-pub use impls::retry_after::RetryAfter;
-pub use impls::token68::Token68;
+pub use self::accept::Accept;
+pub use self::accept_encoding::AcceptEncoding;
+pub use self::allow::Allow;
+pub use self::auth_scheme::AuthScheme;
+pub use self::authorization::Authorization;
+pub use self::content_coding::ContentCoding;
+pub use self::content_encoding::ContentEncoding;
+pub use self::content_length::ContentLength;
+pub use self::content_type::ContentType;
+pub use self::credentials::Credentials;
+pub use self::host::Host;
+pub use self::http_date::HttpDate;
+pub use self::proxy_authorization::ProxyAuthorization;
+pub use self::quality::{Quality, QualityItem};
+pub use self::retry_after::RetryAfter;
+pub use self::token68::Token68;
 
 macro_rules! header {
     // #rule

--- a/src/impls/proxy_authorization.rs
+++ b/src/impls/proxy_authorization.rs
@@ -1,6 +1,6 @@
 use http::header::PROXY_AUTHORIZATION;
 
-use Credentials;
+use super::Credentials;
 
 header! {
     /// `Proxy-Authorization` header, defined in [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.4)
@@ -27,7 +27,7 @@ header! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use {util, Token68};
+    use crate::{util, Token68};
 
     #[test]
     fn rfc1() {

--- a/src/impls/quality.rs
+++ b/src/impls/quality.rs
@@ -39,7 +39,7 @@ where
                 digits[0] = (x % 10) as u8 + b'0';
 
                 let s = unsafe { str::from_utf8_unchecked(&digits[..]) };
-                fmt.write_str(s.trim_right_matches('0'))
+                fmt.write_str(s.trim_end_matches('0'))
             }
         }
     }
@@ -117,7 +117,7 @@ impl<'a> WeightParser<'a> {
 
     fn digit(&mut self) -> Option<u16> {
         match self.peek()? {
-            v @ b'0'...b'9' => {
+            v @ b'0'..=b'9' => {
                 self.next();
                 Some((v - b'0') as u16)
             }

--- a/src/impls/quality.rs
+++ b/src/impls/quality.rs
@@ -184,7 +184,7 @@ impl Quality {
 #[cfg(test)]
 mod test {
     use super::*;
-    use Error;
+    use crate::Error;
 
     #[derive(Debug, Clone, PartialEq)]
     struct Item;

--- a/src/impls/retry_after.rs
+++ b/src/impls/retry_after.rs
@@ -1,6 +1,7 @@
 use http::header::{HeaderName, HeaderValue, ValueIter, RETRY_AFTER};
 
-use {Error, Header, HttpDate, ToValues};
+use crate::{Error, Header, ToValues};
+use super::HttpDate;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RetryAfter {
@@ -47,7 +48,7 @@ impl Header for RetryAfter {
 #[cfg(test)]
 mod test {
     use super::*;
-    use util;
+    use crate::util;
 
     #[test]
     fn rfc1() {

--- a/src/impls/token68.rs
+++ b/src/impls/token68.rs
@@ -12,14 +12,14 @@ impl Token68 {
     /// Constructs a new base68 value.
     #[inline]
     pub fn new(s: &str) -> Result<Token68, InvalidToken68> {
-        let trimmed = s.trim_right_matches('=');
+        let trimmed = s.trim_end_matches('=');
 
         if trimmed.is_empty() {
             return Err(InvalidToken68(()));
         }
 
         let ok = trimmed.as_bytes().iter().all(|b| match b {
-            b'0'...b'9' | b'a'...b'z' | b'A'...b'Z' | b'-' | b'.' | b'_' | b'~' | b'+' | b'/' => {
+            b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' | b'.' | b'_' | b'~' | b'+' | b'/' => {
                 true
             }
             _ => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ impl HeaderMapExt for HeaderMap {
     where
         H: Header,
     {
-        let entry = self.entry(H::name()).unwrap();
+        let entry = self.entry(H::name());
         let mut values = ToValues(ToValuesState::First(entry));
         header.to_values(&mut values);
     }
@@ -176,7 +176,7 @@ impl HeaderMapExt for HeaderMap {
     where
         H: Header,
     {
-        match self.entry(H::name()).unwrap() {
+        match self.entry(H::name()) {
             header::Entry::Occupied(entry) => {
                 let r = H::from_values(&mut entry.iter());
                 entry.remove();

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,9 +12,9 @@ pub fn is_token(s: &str) -> bool {
     }
 
     s.as_bytes().iter().all(|b| match *b {
-        b'a'...b'z'
-        | b'A'...b'Z'
-        | b'0'...b'9'
+        b'a'..=b'z'
+        | b'A'..=b'Z'
+        | b'0'..=b'9'
         | b'!'
         | b'#'
         | b'$'
@@ -39,7 +39,7 @@ pub fn parse_single_value<T>(
 ) -> Result<Option<T>, Error>
 where
     T: FromStr,
-    T::Err: Into<Box<error::Error + Sync + Send>>,
+    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
 {
     match values.next() {
         Some(value) => {
@@ -69,7 +69,7 @@ pub fn parse_comma_delimited<T>(
 ) -> Result<Option<Vec<T>>, Error>
 where
     T: FromStr,
-    T::Err: Into<Box<error::Error + Sync + Send>>,
+    T::Err: Into<Box<dyn error::Error + Sync + Send>>,
 {
     let mut out = vec![];
     let mut empty = true;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use std::error;
 use std::fmt::{self, Write};
 use std::str::FromStr;
 
-use {Error, Header, HeaderMapExt, ToValues};
+use crate::{Error, Header, HeaderMapExt, ToValues};
 
 #[inline]
 pub fn is_token(s: &str) -> bool {


### PR DESCRIPTION
Updates minimum required rustc version due `bytes` dependency.
Switches to 2018 edition.
Also fixes deprecation warnings.
